### PR TITLE
Add subscriber to build for Github pull request review events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <properties>
         <jenkins.version>1.625.1</jenkins.version>
-        <workflow.version>1.14</workflow.version>
+        <workflow.version>2.2</workflow.version>
     </properties>
 
     <scm>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-branch-source</artifactId>
-            <version>2.0.5</version>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/GitHubPullRequestReviewCause.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/GitHubPullRequestReviewCause.java
@@ -1,0 +1,31 @@
+package com.adobe.jenkins.github_pr_comment_build;
+
+import hudson.model.Cause;
+
+/**
+ * Created by Micky Loo on 05/02/2019.
+ */
+public final class GitHubPullRequestReviewCause extends Cause {
+    private final String pullRequestUrl;
+
+    /**
+     * Constructor.
+     * @param pullRequestUrl the URL for the GitHub comment
+     */
+    public GitHubPullRequestReviewCause(String pullRequestUrl) {
+        this.pullRequestUrl = pullRequestUrl;
+    }
+
+    @Override
+    public String getShortDescription() {
+        return "GitHub pull request review";
+    }
+
+    /**
+     * Retrieves the URL for the GitHub pull request for this cause.
+     * @return the URL for the GitHub pull request
+     */
+    public String getPullRequestUrl() {
+        return pullRequestUrl;
+    }
+}

--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/PRReviewGHEventSubscriber.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/PRReviewGHEventSubscriber.java
@@ -1,0 +1,153 @@
+package com.adobe.jenkins.github_pr_comment_build;
+
+import com.cloudbees.jenkins.GitHubRepositoryName;
+import hudson.Extension;
+import hudson.model.CauseAction;
+import hudson.model.Item;
+import hudson.model.Job;
+import hudson.security.ACL;
+import jenkins.branch.BranchProperty;
+import jenkins.branch.MultiBranchProject;
+import jenkins.model.ParameterizedJobMixIn;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceOwner;
+import jenkins.scm.api.SCMSourceOwners;
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.github.extension.GHEventsSubscriber;
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
+import org.kohsuke.github.GHEvent;
+
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.collect.Sets.immutableEnumSet;
+import static org.kohsuke.github.GHEvent.PULL_REQUEST_REVIEW;
+
+/**
+ * This subscriber manages {@link GHEvent} PULL_REQUEST_REVIEW edits.
+ */
+@Extension
+public class PRReviewGHEventSubscriber extends GHEventsSubscriber {
+    /**
+     * Logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(PRReviewGHEventSubscriber.class.getName());
+    /**
+     * Regex pattern for a GitHub repository.
+     */
+    private static final Pattern REPOSITORY_NAME_PATTERN = Pattern.compile("https?://([^/]+)/([^/]+)/([^/]+)");
+
+    @Override
+    protected boolean isApplicable(Item item) {
+        if (item != null && item instanceof Job<?, ?>) {
+            Job<?, ?> project = (Job<?, ?>) item;
+            if (project.getParent() instanceof SCMSourceOwner) {
+                SCMSourceOwner owner = (SCMSourceOwner) project.getParent();
+                for (SCMSource source : owner.getSCMSources()) {
+                    if (source instanceof GitHubSCMSource) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected Set<GHEvent> events() {
+        return immutableEnumSet(PULL_REQUEST_REVIEW);
+    }
+
+    /**
+     * Handles updates of pull requests.
+     * @param event only PULL_REQUEST_REVIEW events
+     * @param payload payload of gh-event. Never blank
+     */
+    @Override
+    protected void onEvent(GHEvent event, String payload) {
+        JSONObject json = JSONObject.fromObject(payload);
+
+        JSONObject pullRequest = json.getJSONObject("pull_request");
+        final String pullRequestUrl = pullRequest.getString("html_url");
+        Integer pullRequestId = pullRequest.getInt("number");
+
+        // Set some values used below
+        final Pattern pullRequestJobNamePattern = Pattern.compile("^PR-" + pullRequestId + "\\b.*$",
+                Pattern.CASE_INSENSITIVE);
+
+        // Make sure the repository URL is valid
+        String repoUrl = json.getJSONObject("repository").getString("html_url");
+        Matcher matcher = REPOSITORY_NAME_PATTERN.matcher(repoUrl);
+        if (!matcher.matches()) {
+            LOGGER.log(Level.WARNING, "Malformed repository URL {0}", repoUrl);
+            return;
+        }
+        final GitHubRepositoryName changedRepository = GitHubRepositoryName.create(repoUrl);
+        if (changedRepository == null) {
+            LOGGER.log(Level.WARNING, "Malformed repository URL {0}", repoUrl);
+            return;
+        }
+
+        LOGGER.log(Level.FINE, "Received review on PR {1} for {2}", new Object[] { pullRequestId, repoUrl });
+        ACL.impersonate(ACL.SYSTEM, new Runnable() {
+            @Override
+            public void run() {
+                boolean jobFound = false;
+                for (final SCMSourceOwner owner : SCMSourceOwners.all()) {
+                    for (SCMSource source : owner.getSCMSources()) {
+                        if (!(source instanceof GitHubSCMSource)) {
+                            continue;
+                        }
+                        GitHubSCMSource gitHubSCMSource = (GitHubSCMSource) source;
+                        if (gitHubSCMSource.getRepoOwner().equalsIgnoreCase(changedRepository.getUserName()) &&
+                                gitHubSCMSource.getRepository().equalsIgnoreCase(changedRepository.getRepositoryName())) {
+                            for (Job<?, ?> job : owner.getAllJobs()) {
+                                if (pullRequestJobNamePattern.matcher(job.getName()).matches()) {
+                                    if (!(job.getParent() instanceof MultiBranchProject)) {
+                                        continue;
+                                    }
+                                    boolean propFound = false;
+                                    for (BranchProperty prop : ((MultiBranchProject) job.getParent()).getProjectFactory().
+                                            getBranch(job).getProperties()) {
+                                        if (!(prop instanceof TriggerPRReviewBranchProperty)) {
+                                            continue;
+                                        }
+                                        propFound = true;
+                                        ParameterizedJobMixIn.scheduleBuild2(job, 0,
+                                                new CauseAction(new GitHubPullRequestReviewCause(pullRequestUrl)));
+                                        break;
+                                    }
+
+                                    if (!propFound) {
+                                        LOGGER.log(Level.FINE,
+                                                "Job {0} for {1}:{2}/{3} does not have a trigger PR review branch property",
+                                                new Object[] {
+                                                        job.getFullName(),
+                                                        changedRepository.getHost(),
+                                                        changedRepository.getUserName(),
+                                                        changedRepository.getRepositoryName()
+                                                }
+                                        );
+                                    }
+
+                                    jobFound = true;
+                                }
+                            }
+                        }
+                    }
+                }
+                if (!jobFound) {
+                    LOGGER.log(Level.FINE, "PR review on {0}:{1}/{2} did not match any job",
+                            new Object[] {
+                                    changedRepository.getHost(), changedRepository.getUserName(),
+                                    changedRepository.getRepositoryName()
+                            }
+                    );
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/TriggerPRReviewBranchProperty.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/TriggerPRReviewBranchProperty.java
@@ -1,0 +1,36 @@
+package com.adobe.jenkins.github_pr_comment_build;
+
+import hudson.Extension;
+import hudson.model.Job;
+import hudson.model.Run;
+import jenkins.branch.BranchProperty;
+import jenkins.branch.BranchPropertyDescriptor;
+import jenkins.branch.JobDecorator;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Allows a GitHub pull request update to trigger an immediate build.
+ */
+public class TriggerPRReviewBranchProperty extends BranchProperty {
+
+    /**
+     * Constructor.
+     */
+    @DataBoundConstructor
+    public TriggerPRReviewBranchProperty() { }
+
+    @Override
+    public <P extends Job<P, B>, B extends Run<P, B>> JobDecorator<P, B> jobDecorator(Class<P> clazz) {
+        return null;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BranchPropertyDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.TriggerPRReviewBranchProperty_trigger_on_pull_request_review();
+        }
+
+    }
+}

--- a/src/main/resources/com/adobe/jenkins/github_pr_comment_build/Messages.properties
+++ b/src/main/resources/com/adobe/jenkins/github_pr_comment_build/Messages.properties
@@ -1,2 +1,3 @@
 TriggerPRCommentBranchProperty.trigger_on_pull_request_comment=Trigger build on pull request comment
 TriggerPRUpdateBranchProperty.trigger_on_pull_request_update=Trigger build on pull request update
+TriggerPRReviewBranchProperty.trigger_on_pull_request_review=Trigger build on pull request review

--- a/src/main/resources/com/adobe/jenkins/github_pr_comment_build/TriggerPRReviewBranchProperty/help.html
+++ b/src/main/resources/com/adobe/jenkins/github_pr_comment_build/TriggerPRReviewBranchProperty/help.html
@@ -1,0 +1,4 @@
+<div>
+    This property will cause a job for a pull request (PR-*) to be triggered immediately when a review is made
+    on the PR in GitHub.  This has no effect on jobs that are not for pull requests.
+</div>


### PR DESCRIPTION
@bluesliverx 
PR for https://github.com/jenkinsci/github-pr-comment-build-plugin/issues/10

I had to bump the version of github-branch-source dependency to 2.3.0.  This is the minimum version that supports pull request review events.

Also had to bump the version of workflow.version to 2.2, I was having test failures otherwise with  maven-surefire-plugin default-test.  
