### PR TITLE
[JENKINS-63938] Add storage of commentBody in GitHubPullRequestCommentCause

### DIFF
--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/GitHubPullRequestCommentCause.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/GitHubPullRequestCommentCause.java
@@ -12,15 +12,6 @@ public final class GitHubPullRequestCommentCause extends Cause {
     /**
      * Constructor.
      * @param commentUrl the URL for the GitHub comment
-     */
-    public GitHubPullRequestCommentCause(String commentUrl) {
-        this.commentUrl = commentUrl;
-        this.commentBody = "Unknown";
-    }
-
-    /**
-     * Constructor.
-     * @param commentUrl the URL for the GitHub comment
      * @param commentBody the body for the GitHub comment
      */
     public GitHubPullRequestCommentCause(String commentUrl, String commentBody) {

--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/GitHubPullRequestCommentCause.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/GitHubPullRequestCommentCause.java
@@ -7,6 +7,7 @@ import hudson.model.Cause;
  */
 public final class GitHubPullRequestCommentCause extends Cause {
     private final String commentUrl;
+    private final String commentBody;
 
     /**
      * Constructor.
@@ -14,6 +15,17 @@ public final class GitHubPullRequestCommentCause extends Cause {
      */
     public GitHubPullRequestCommentCause(String commentUrl) {
         this.commentUrl = commentUrl;
+        this.commentBody = "Unknown";
+    }
+
+    /**
+     * Constructor.
+     * @param commentUrl the URL for the GitHub comment
+     * @param commentBody the body for the GitHub comment
+     */
+    public GitHubPullRequestCommentCause(String commentUrl, String commentBody) {
+        this.commentUrl = commentUrl;
+        this.commentBody = commentBody;
     }
 
     @Override
@@ -27,5 +39,13 @@ public final class GitHubPullRequestCommentCause extends Cause {
      */
     public String getCommentUrl() {
         return commentUrl;
+    }
+
+    /**
+     * Retrieves the body for the GitHub comment for this cause.
+     * @return the body for the GitHub comment
+     */
+    public String getCommentBody() {
+        return commentBody;
     }
 }

--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/IssueCommentGHEventSubscriber.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/IssueCommentGHEventSubscriber.java
@@ -149,7 +149,7 @@ public class IssueCommentGHEventSubscriber extends GHEventsSubscriber {
                                                 Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
                                         if (commentBody == null || pattern.matcher(commentBody).matches()) {
                                             ParameterizedJobMixIn.scheduleBuild2(job, 0,
-                                                    new CauseAction(new GitHubPullRequestCommentCause(commentUrl)));
+                                                    new CauseAction(new GitHubPullRequestCommentCause(commentUrl, commentBody)));
                                             LOGGER.log(Level.FINE,
                                                     "Triggered build for {0} due to PR comment on {1}:{2}/{3}",
                                                     new Object[] {


### PR DESCRIPTION
This PR is to address the first part of the issue presented by #22 by adding the storage of the GitHub
comment body to the resulting build cause. With this, one can now easily retreive the comment body
that triggered the build to start so that it can be parsed during the build.  Further work can
be done on top of this PR to store this information as an environment variable on the Jenkins job
itself, but this alone helps to remove the need to create an API call out to GitHub for information
that was already sent in the initial webhook.
