### PR TITLE
#33 Add exported attributes to generate better JSON

### DIFF
--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/GitHubPullRequestCommentCause.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/GitHubPullRequestCommentCause.java
@@ -2,6 +2,7 @@ package com.adobe.jenkins.github_pr_comment_build;
 
 import hudson.model.Cause;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.kohsuke.stapler.export.Exported;
 
 import java.io.Serializable;
 
@@ -36,6 +37,7 @@ public final class GitHubPullRequestCommentCause extends Cause implements Serial
      * @return the URL for the GitHub comment
      */
     @Whitelisted
+    @Exported(visibility = 3)
     public String getCommentUrl() {
         return commentUrl;
     }
@@ -45,6 +47,7 @@ public final class GitHubPullRequestCommentCause extends Cause implements Serial
      * @return the author of the GitHub comment
      */
     @Whitelisted
+    @Exported(visibility = 3)
     public String getCommentAuthor() {
         return commentAuthor;
     }
@@ -54,6 +57,7 @@ public final class GitHubPullRequestCommentCause extends Cause implements Serial
      * @return the body for the GitHub comment
      */
     @Whitelisted
+    @Exported(visibility = 3)
     public String getCommentBody() {
         return commentBody;
     }

--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/GitHubPullRequestReviewCause.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/GitHubPullRequestReviewCause.java
@@ -2,6 +2,7 @@ package com.adobe.jenkins.github_pr_comment_build;
 
 import hudson.model.Cause;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.kohsuke.stapler.export.Exported;
 
 import java.io.Serializable;
 
@@ -30,6 +31,7 @@ public final class GitHubPullRequestReviewCause extends Cause implements Seriali
      * @return the URL for the GitHub pull request
      */
     @Whitelisted
+    @Exported(visibility = 3)
     public String getPullRequestUrl() {
         return pullRequestUrl;
     }

--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/GitHubPullRequestUpdateCause.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/GitHubPullRequestUpdateCause.java
@@ -2,6 +2,7 @@ package com.adobe.jenkins.github_pr_comment_build;
 
 import hudson.model.Cause;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.kohsuke.stapler.export.Exported;
 
 import java.io.Serializable;
 
@@ -30,6 +31,7 @@ public final class GitHubPullRequestUpdateCause extends Cause implements Seriali
      * @return the URL for the GitHub pull request
      */
     @Whitelisted
+    @Exported(visibility = 3)
     public String getPullRequestUrl() {
         return pullRequestUrl;
     }


### PR DESCRIPTION
The JSON generated from `currentBuild.getBuildCauses()` does not include the properties describing the comment. Looking at the built-in causes, it looks like they use this property and that allows the JSON to be generated with the correct fields.