### PR TITLE
Add configurable minimum permissions for triggers

### DIFF
--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/IssueCommentGHEventSubscriber.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/IssueCommentGHEventSubscriber.java
@@ -149,7 +149,7 @@ public class IssueCommentGHEventSubscriber extends GHEventsSubscriber {
                                     propFound = true;
                                     TriggerPRCommentBranchProperty branchProp = (TriggerPRCommentBranchProperty)prop;
                                     String expectedCommentBody = branchProp.getCommentBody();
-                                    if (!branchProp.isAllowUntrusted() && !GithubHelper.isAuthorized(job, commentAuthor)) {
+                                    if (!GithubHelper.isAuthorized(job, commentAuthor, branchProp.getMinimumPermissions())) {
                                         continue;
                                     }
                                     Pattern pattern = Pattern.compile(expectedCommentBody,

--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/PRReviewGHEventSubscriber.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/PRReviewGHEventSubscriber.java
@@ -120,7 +120,7 @@ public class PRReviewGHEventSubscriber extends GHEventsSubscriber {
                                         continue;
                                     }
                                     TriggerPRReviewBranchProperty branchProp = (TriggerPRReviewBranchProperty)prop;
-                                    if (!branchProp.isAllowUntrusted() && !GithubHelper.isAuthorized(job, author)) {
+                                    if (!GithubHelper.isAuthorized(job, author, branchProp.getMinimumPermissions())) {
                                         continue;
                                     }
                                     propFound = true;

--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/PRUpdateGHEventSubscriber.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/PRUpdateGHEventSubscriber.java
@@ -135,7 +135,7 @@ public class PRUpdateGHEventSubscriber extends GHEventsSubscriber {
                                         continue;
                                     }
                                     TriggerPRUpdateBranchProperty branchProp = (TriggerPRUpdateBranchProperty)prop;
-                                    if (!branchProp.isAllowUntrusted() && !GithubHelper.isAuthorized(job, author)) {
+                                    if (!GithubHelper.isAuthorized(job, author, branchProp.getMinimumPermissions())) {
                                         continue;
                                     }
                                     propFound = true;

--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/TriggerBranchProperty.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/TriggerBranchProperty.java
@@ -1,0 +1,44 @@
+package com.adobe.jenkins.github_pr_comment_build;
+
+import hudson.model.Job;
+import hudson.model.Run;
+import jenkins.branch.BranchProperty;
+import jenkins.branch.JobDecorator;
+import org.kohsuke.stapler.DataBoundSetter;
+
+/**
+ * Common parts of TriggerPR*BranchProperty classes
+ */
+abstract public class TriggerBranchProperty extends BranchProperty {
+    protected boolean allowUntrusted;
+    protected String minimumPermissions;
+
+    @Deprecated
+    public boolean isAllowUntrusted() {
+        return allowUntrusted;
+    }
+
+    @DataBoundSetter
+    @Deprecated
+    public void setAllowUntrusted(boolean allowUntrusted) {
+        this.allowUntrusted = allowUntrusted;
+    }
+
+    @DataBoundSetter
+    public void setMinimumPermissions(String minimumPermissions) {
+        this.minimumPermissions = minimumPermissions;
+    }
+
+    public String getMinimumPermissions() {
+        if (minimumPermissions == null || minimumPermissions.isEmpty()) {
+            return this.allowUntrusted ? "NONE" : "WRITE";
+        }
+        return minimumPermissions;
+    }
+
+    @Override
+    public <P extends Job<P, B>, B extends Run<P, B>> JobDecorator<P, B> jobDecorator(Class<P> clazz) {
+        return null;
+    }
+}
+

--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/TriggerBranchPropertyDescriptorImpl.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/TriggerBranchPropertyDescriptorImpl.java
@@ -1,0 +1,28 @@
+package com.adobe.jenkins.github_pr_comment_build;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.util.ListBoxModel;
+import jenkins.branch.BranchPropertyDescriptor;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.github.GHPermissionType;
+
+abstract public class TriggerBranchPropertyDescriptorImpl extends BranchPropertyDescriptor {
+
+    /**
+     * Populates the minimum permissions options.
+     *
+     * @return the minimum permissions options.
+     */
+    @NonNull
+    @Restricted(NoExternalUse.class)
+    @SuppressWarnings("unused") // stapler
+    public ListBoxModel doFillMinimumPermissionsItems() {
+        ListBoxModel result = new ListBoxModel();
+        result.add("Only users with admin permission", String.valueOf(GHPermissionType.ADMIN));
+        result.add("Only users that can push to the repository", String.valueOf(GHPermissionType.WRITE));
+        result.add("Allow untrusted users to trigger the build", String.valueOf(GHPermissionType.NONE));
+        return result;
+    }
+
+}

--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/TriggerPRCommentBranchProperty.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/TriggerPRCommentBranchProperty.java
@@ -1,23 +1,16 @@
 package com.adobe.jenkins.github_pr_comment_build;
 
 import hudson.Extension;
-import hudson.model.Job;
-import hudson.model.Run;
-import jenkins.branch.BranchProperty;
-import jenkins.branch.BranchPropertyDescriptor;
-import jenkins.branch.JobDecorator;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * Allows a GitHub pull request comment to trigger an immediate build based on a comment string.
  */
-public class TriggerPRCommentBranchProperty extends BranchProperty {
+public class TriggerPRCommentBranchProperty extends TriggerBranchProperty {
     /**
      * The comment body to trigger a new build on.
      */
     private final String commentBody;
-    private boolean allowUntrusted;
 
     /**
      * Constructor.
@@ -39,27 +32,12 @@ public class TriggerPRCommentBranchProperty extends BranchProperty {
         return commentBody;
     }
 
-    public boolean isAllowUntrusted() {
-        return allowUntrusted;
-    }
-
-    @DataBoundSetter
-    public void setAllowUntrusted(boolean allowUntrusted) {
-        this.allowUntrusted = allowUntrusted;
-    }
-
-    @Override
-    public <P extends Job<P, B>, B extends Run<P, B>> JobDecorator<P, B> jobDecorator(Class<P> clazz) {
-        return null;
-    }
-
     @Extension
-    public static class DescriptorImpl extends BranchPropertyDescriptor {
+    public static class DescriptorImpl extends TriggerBranchPropertyDescriptorImpl {
 
         @Override
         public String getDisplayName() {
             return Messages.TriggerPRCommentBranchProperty_trigger_on_pull_request_comment();
         }
-
     }
 }

--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/TriggerPRReviewBranchProperty.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/TriggerPRReviewBranchProperty.java
@@ -1,47 +1,25 @@
 package com.adobe.jenkins.github_pr_comment_build;
 
 import hudson.Extension;
-import hudson.model.Job;
-import hudson.model.Run;
-import jenkins.branch.BranchProperty;
-import jenkins.branch.BranchPropertyDescriptor;
-import jenkins.branch.JobDecorator;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * Allows a GitHub pull request update to trigger an immediate build.
  */
-public class TriggerPRReviewBranchProperty extends BranchProperty {
-    private boolean allowUntrusted;
+public class TriggerPRReviewBranchProperty extends TriggerBranchProperty {
 
     /**
      * Constructor.
      */
     @DataBoundConstructor
-    public TriggerPRReviewBranchProperty() { }
-
-    public boolean isAllowUntrusted() {
-        return allowUntrusted;
-    }
-
-    @DataBoundSetter
-    public void setAllowUntrusted(boolean allowUntrusted) {
-        this.allowUntrusted = allowUntrusted;
-    }
-
-    @Override
-    public <P extends Job<P, B>, B extends Run<P, B>> JobDecorator<P, B> jobDecorator(Class<P> clazz) {
-        return null;
-    }
+    public TriggerPRReviewBranchProperty() {}
 
     @Extension
-    public static class DescriptorImpl extends BranchPropertyDescriptor {
+    public static class DescriptorImpl extends TriggerBranchPropertyDescriptorImpl {
 
         @Override
         public String getDisplayName() {
             return Messages.TriggerPRReviewBranchProperty_trigger_on_pull_request_review();
         }
-
     }
 }

--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/TriggerPRUpdateBranchProperty.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/TriggerPRUpdateBranchProperty.java
@@ -1,47 +1,25 @@
 package com.adobe.jenkins.github_pr_comment_build;
 
 import hudson.Extension;
-import hudson.model.Job;
-import hudson.model.Run;
-import jenkins.branch.BranchProperty;
-import jenkins.branch.BranchPropertyDescriptor;
-import jenkins.branch.JobDecorator;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * Allows a GitHub pull request update to trigger an immediate build.
  */
-public class TriggerPRUpdateBranchProperty extends BranchProperty {
-    private boolean allowUntrusted;
+public class TriggerPRUpdateBranchProperty extends TriggerBranchProperty {
 
     /**
      * Constructor.
      */
     @DataBoundConstructor
-    public TriggerPRUpdateBranchProperty() { }
-
-    public boolean isAllowUntrusted() {
-        return allowUntrusted;
-    }
-
-    @DataBoundSetter
-    public void setAllowUntrusted(boolean allowUntrusted) {
-        this.allowUntrusted = allowUntrusted;
-    }
-
-    @Override
-    public <P extends Job<P, B>, B extends Run<P, B>> JobDecorator<P, B> jobDecorator(Class<P> clazz) {
-        return null;
-    }
+    public TriggerPRUpdateBranchProperty() {}
 
     @Extension
-    public static class DescriptorImpl extends BranchPropertyDescriptor {
+    public static class DescriptorImpl extends TriggerBranchPropertyDescriptorImpl {
 
         @Override
         public String getDisplayName() {
             return Messages.TriggerPRUpdateBranchProperty_trigger_on_pull_request_update();
         }
-
     }
 }

--- a/src/main/resources/com/adobe/jenkins/github_pr_comment_build/TriggerPRCommentBranchProperty/config.jelly
+++ b/src/main/resources/com/adobe/jenkins/github_pr_comment_build/TriggerPRCommentBranchProperty/config.jelly
@@ -5,7 +5,7 @@
     <f:entry title="Comment Body" field="commentBody">
         <f:textbox />
     </f:entry>
-    <f:entry title="Allow untrusted users to trigger the build" field="allowUntrusted">
-        <f:checkbox default="false"/>
+    <f:entry field="minimumPermissions" title="Minimum Permissions on repository to trigger the build">
+        <f:select default="WRITE" />
     </f:entry>
 </j:jelly>

--- a/src/main/resources/com/adobe/jenkins/github_pr_comment_build/TriggerPRCommentBranchProperty/help-commentBody.html
+++ b/src/main/resources/com/adobe/jenkins/github_pr_comment_build/TriggerPRCommentBranchProperty/help-commentBody.html
@@ -1,4 +1,4 @@
 <div>
     The comment body to trigger a new build for a PR job when it is received. This is compiled as a
-    case insensitive regular expression, so use ".*" to trigger a build on any comment whatsoever.
+    case-insensitive regular expression, so use ".*" to trigger a build on any comment whatsoever.
 </div>

--- a/src/main/resources/com/adobe/jenkins/github_pr_comment_build/TriggerPRReviewBranchProperty/config.jelly
+++ b/src/main/resources/com/adobe/jenkins/github_pr_comment_build/TriggerPRReviewBranchProperty/config.jelly
@@ -2,7 +2,7 @@
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <f:entry title="Allow untrusted users to trigger the build" field="allowUntrusted">
-        <f:checkbox default="false"/>
+    <f:entry field="minimumPermissions" title="Minimum Permissions on repository to trigger the build">
+        <f:select default="WRITE" />
     </f:entry>
 </j:jelly>

--- a/src/main/resources/com/adobe/jenkins/github_pr_comment_build/TriggerPRUpdateBranchProperty/config.jelly
+++ b/src/main/resources/com/adobe/jenkins/github_pr_comment_build/TriggerPRUpdateBranchProperty/config.jelly
@@ -2,7 +2,7 @@
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <f:entry title="Allow untrusted users to trigger the build" field="allowUntrusted">
-        <f:checkbox default="false"/>
+    <f:entry field="minimumPermissions" title="Minimum Permissions on repository to trigger the build">
+        <f:select default="WRITE" />
     </f:entry>
 </j:jelly>


### PR DESCRIPTION
For private repositories people with `Read` role (aka `pull` permission) are seen as collaborators
by the GitHub API. This means, they were able trigger builds with older versions of the plugin.

This change fixes this, and also adds the option to limit triggering of builds to repository admins.

The existing `allowUntrusted` toggle is dropped from the UI.
This change adds a new drop-down `Minimum Permissions on repository to trigger the build` with these options:
- Only users with admin permission
- Only users that can push to the repository (default)
- Allow untrusted users to trigger the build

Use-case for the "admin" part:
- We have PR builds in our organization that need access to credentials with a high blast radius. 
- For repos with these builds all developers in the organisation have write access, but merging to master is restricted to admins (via `.github/CODEOWNERS`).
- Allowing everyone to trigger builds is dangerous, as the `Jenkinsfile` and other scripts that are used in the build could be modified by people with bad intend / hacked accounts. So we also want to be able to limit triggering of builds to admins only.
 
![Bildschirm­foto 2023-03-06 um 15 53 27](https://user-images.githubusercontent.com/2102878/223145619-47f1fafa-f868-41e3-afa8-3d228b870783.png)

