### PR TITLE
Correctly ignore non-label events in label event handler

### DIFF
--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/IssueLabelGHEventSubscriber.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/IssueLabelGHEventSubscriber.java
@@ -93,17 +93,17 @@ public class IssueLabelGHEventSubscriber extends GHEventsSubscriber {
 
         final Pattern pullRequestJobNamePattern = Pattern.compile("^PR-" + pullRequestId + "\\b.*$", Pattern.CASE_INSENSITIVE);
 
-        final String label = json.getJSONObject("label").getString("name");
-        final String labelUrl = json.getJSONObject("label").getString("url");
-
-        // Make sure the action is edited or created (not deleted)
+        // Make sure the action is labeled
         String action = json.getString("action");
         if (!ACTION_LABELED.equals(action)) {
-            LOGGER.log(Level.FINER, "Event is labeled ({0}) for PR {1}",
+            LOGGER.log(Level.FINER, "Event is not labeled ({0}) for PR {1}, ignoring",
                     new Object[]{action, pullRequestUrl}
             );
             return;
         }
+
+        final String label = json.getJSONObject("label").getString("name");
+        final String labelUrl = json.getJSONObject("label").getString("url");
 
         // Make sure the repository URL is valid
         String repoUrl = json.getJSONObject("repository").getString("html_url");


### PR DESCRIPTION
This fixes the following error that occurs in our jenkins log on each GitHub event that is not of action `labeled`:
```
SEVERE  o.j.p.g.e.GHEventsSubscriber$4#applyNullSafe: Subscriber com.adobe.jenkins.github_pr_comment_build.IssueLabelGHEventSubscriber failed to process SCMEvent{type=UPDATED,…} hook, skipping...

net.sf.json.JSONException: null object
at net.sf.json.JSONObject.verifyIsNull(JSONObject.java:2688)
at net.sf.json.JSONObject.getString(JSONObject.java:2035)
at com.adobe.jenkins.github_pr_comment_build.IssueLabelGHEventSubscriber.onEvent(IssueLabelGHEventSubscriber.java:96)
at org.jenkinsci.plugins.github.extension.GHEventsSubscriber.onEvent(GHEventsSubscriber.java:142)
at org.jenkinsci.plugins.github.extension.GHEventsSubscriber$4.applyNullSafe(GHEventsSubscriber.java:241)
at org.jenkinsci.plugins.github.extension.GHEventsSubscriber$4.applyNullSafe(GHEventsSubscriber.java:237)
at org.jenkinsci.plugins.github.util.misc.NullSafeFunction.apply(NullSafeFunction.java:18)

```

### Testing done

Tested on our internal jenkins test instance.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- ~~[ ] Link to relevant issues in GitHub or Jira~~
- ~~[ ] Link to relevant pull requests, esp. upstream and downstream changes~~
- ~~[ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
