### PR TITLE
Correct minimum permissions for label trigger (#71)

### DIFF
--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/TriggerPRLabelBranchProperty.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/TriggerPRLabelBranchProperty.java
@@ -3,7 +3,6 @@ package com.adobe.jenkins.github_pr_comment_build;
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
-import jenkins.branch.BranchPropertyDescriptor;
 import jenkins.branch.JobDecorator;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -41,7 +40,7 @@ public class TriggerPRLabelBranchProperty extends TriggerBranchProperty {
     }
 
     @Extension
-    public static class DescriptorImpl extends BranchPropertyDescriptor {
+    public static class DescriptorImpl extends TriggerBranchPropertyDescriptorImpl {
 
         @Override
         public String getDisplayName() {

--- a/src/main/resources/com/adobe/jenkins/github_pr_comment_build/TriggerPRCommentBranchProperty/config.jelly
+++ b/src/main/resources/com/adobe/jenkins/github_pr_comment_build/TriggerPRCommentBranchProperty/config.jelly
@@ -2,7 +2,7 @@
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <f:entry title="Comment Body" field="commentBody">
+    <f:entry title="Comment Body Regex" field="commentBody">
         <f:textbox />
     </f:entry>
     <f:entry field="minimumPermissions" title="Minimum Permissions on repository to trigger the build">

--- a/src/main/resources/com/adobe/jenkins/github_pr_comment_build/TriggerPRLabelBranchProperty/config.jelly
+++ b/src/main/resources/com/adobe/jenkins/github_pr_comment_build/TriggerPRLabelBranchProperty/config.jelly
@@ -2,7 +2,7 @@
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <f:entry title="gitHub label regex" field="label">
+    <f:entry field="label" title="GitHub Label Regex">
         <f:textbox />
     </f:entry>
     <f:entry field="minimumPermissions" title="Minimum Permissions on repository to trigger the build">


### PR DESCRIPTION
This is a simple fix to correct the inheriting class to get the minimum permissions filled out correctly.