### PR TITLE
Fix pattern matching to use find() instead of matches()

### DIFF
--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/IssueCommentGHEventSubscriber.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/IssueCommentGHEventSubscriber.java
@@ -117,7 +117,7 @@ public class IssueCommentGHEventSubscriber extends BasePRGHEventSubscriber<Trigg
             String expectedCommentBody = branchProp.getCommentBody();
             Pattern pattern = Pattern.compile(expectedCommentBody,
                     Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
-            if (commentBody == null || pattern.matcher(commentBody).matches()) {
+            if (commentBody == null || pattern.matcher(commentBody).find()) {
                 // Comment matches, return a cause to trigger the job to start
                 return new GitHubPullRequestCommentCause(commentUrl, commentAuthor, commentBody);
             }

--- a/src/main/java/com/adobe/jenkins/github_pr_comment_build/IssueLabelGHEventSubscriber.java
+++ b/src/main/java/com/adobe/jenkins/github_pr_comment_build/IssueLabelGHEventSubscriber.java
@@ -80,7 +80,7 @@ public class IssueLabelGHEventSubscriber extends BasePRGHEventSubscriber<Trigger
             String expectedLabel = branchProp.getLabel();
             Pattern pattern = Pattern.compile(expectedLabel,
                     Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
-            if (pattern.matcher(label).matches()) {
+            if (pattern.matcher(label).find()) {
                 return new GitHubPullRequestLabelCause(labelUrl, labellingAuthor, label);
             }
             LOGGER.log(Level.FINER,


### PR DESCRIPTION
Changes  to  for regex pattern matching in both comment and label event subscribers. This allows partial matches (substring matching) rather than requiring the entire string to match the pattern.

fixes #93 

implemented by opencode - i didn't see how one is supposed to validate/test